### PR TITLE
Prevent form submits by apply and delete buttons

### DIFF
--- a/src/code-editor/index.js
+++ b/src/code-editor/index.js
@@ -128,7 +128,8 @@ export class CodeEditor {
         this.cssCodeEditor.refresh();
     }
 
-    updateHtml() {
+    updateHtml(e) {
+        e?.preventDefault();
         const { editor, component } = this;
         let htmlCode = this.htmlCodeEditor.getContent().trim();
         if (!htmlCode || htmlCode === this.previousHtmlCode) return;
@@ -148,7 +149,8 @@ export class CodeEditor {
         editor.select(component.replaceWith(htmlCode));
     }
 
-    updateCss() {
+    updateCss(e) {
+        e?.preventDefault();
         const cssCode = this.cssCodeEditor.getContent().trim();
         if (!cssCode || cssCode === this.previousCssCode) return;
         this.parseRemove(cssCode);
@@ -156,7 +158,8 @@ export class CodeEditor {
         this.editor.Components.addComponent(`<style>${cssCode}</style>`);
     }
 
-    deleteSelectedCss() {
+    deleteSelectedCss(e) {
+        e?.preventDefault();
         const selections = this.cssCodeEditor.editor.getSelections();
         selections.forEach(selection => this.parseRemove(selection));
         this.cssCodeEditor.editor.deleteH();


### PR DESCRIPTION
Apply and delete buttons try to submit form if editor is placed inside of one. This PR intention is to stop them from doing this.