### PR TITLE
fix: preserve media queries when applying HTML changes

### DIFF
--- a/src/code-editor/index.js
+++ b/src/code-editor/index.js
@@ -140,6 +140,7 @@ export class CodeEditor {
         this.previousHtmlCode = htmlCode;
 
         let idStyles = '';
+
         this.cssCodeEditor
             .getContent()
             .split('}\n')
@@ -147,11 +148,15 @@ export class CodeEditor {
             .map((cssObjectRule) => {
                 if (!(/}$/.test(cssObjectRule))) {
                     //* Have to check closing bracket existence for every rule cause it can be missed after split and add it if it doesnt match
+                    if (/@media[^{]*{[^}]*#/.test(cssObjectRule)) {
+                        // Media queries need double closing brackets
+                        return `${cssObjectRule}}}`;
+                    }
                     return `${cssObjectRule}}`;
                 }
             })
             .forEach(rule => {
-                if (/^#/.test(rule))
+                if (/^#|@media[^{]*{[^}]*#/.test(rule))
                     idStyles += rule;
             });
 


### PR DESCRIPTION
Fix CSS parsing for media queries containing ID selectors

- Updated regex pattern to detect media queries with ID selectors (@media[^{]*{[^}]*#)
- Fixed bracket handling for media queries by adding double closing brackets (}}) when missing
- Ensures proper CSS formatting for both direct ID rules and media query wrapped ID rules

This resolves issues where media queries containing ID selectors were not being processed correctly due to incomplete bracket matching.